### PR TITLE
Fix issues with deletion of individual jobs from failure queue

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -1,6 +1,6 @@
 class JobsController < ApplicationController
   def destroy
-    Resque::Failure.remove(params[:index])
-    redirect_to failure_path(params[:failure_id])
+    Resque::Failure.remove(params[:id])
+    redirect_to failures_path(:queue => params[:failure_id])
   end
 end


### PR DESCRIPTION
- The wrong params was being pulled so the call to Resque::Failure.remove
  was essentially Resque::Failure.remove(nil). Changed to use params[:id]
  instead of params[:index]
- After job is removed,  controller redirected to
  FailuresController#show. This view is broken and seems to be redundent
  (or possibly needs refactoring). The FailuresController#index view
  provides the same view FailuresController#show does if you pass the
  :queue param
