### PR TITLE
Fixes issue with retrying a job (issue #4)

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -1,6 +1,23 @@
 class JobsController < ApplicationController
+
   def destroy
     Resque::Failure.remove(params[:id])
-    redirect_to failures_path(:queue => params[:failure_id])
+    redirect_to failures_path(failures_params)
   end
+
+  def retry
+    Resque::Failure.requeue(params[:id])
+    redirect_to failures_path(failures_params)
+  end
+
+  private
+
+  def failures_params
+    {}.tap do |failures_params|
+      if params[:failure_id].present?
+        failures_params[:queue] = params[:failures_id]
+      end
+    end
+  end
+
 end

--- a/app/helpers/failures_helper.rb
+++ b/app/helpers/failures_helper.rb
@@ -2,7 +2,7 @@ module FailuresHelper
   def each_failure(&block)
     Resque::Failure.each(failure_start_at, failure_per_page, params[:queue], params[:class], &block)
   end
-  
+
   def failure_date_format
     "%Y/%m/%d %T %z"
   end

--- a/app/views/failures/_failed_job.html.erb
+++ b/app/views/failures/_failed_job.html.erb
@@ -17,9 +17,9 @@
         </div>
       <% else %>
         <div class="controls">
-          <%= link_to "Retry", "/failures/#{failure_queue}/retry/#{id}", :method => :put %>
+          <%= link_to "Retry", retry_failure_job_path(:failure_id=>failure_queue,:id=>id), :method => :put %>
           or
-          <%= link_to "Remove", "/failures/#{failure_queue}/jobs/#{id}", :method => :delete %>
+          <%= link_to "Remove", failure_job_path(:failure_id=>failure_queue,:id=>id), :method => :delete %>
         </div>
       <% end %>
     </dd>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,9 @@ ResqueWeb::Application.routes.draw do
 
   resources :failures, :constraints => {:failure_id => id_pattern, :id => id_pattern} do
     resources :retry
-    resources :jobs
+    resources :jobs do
+      put 'retry', :on => :member
+    end
   end
 
   delete '/failures' => "failures#destroy"


### PR DESCRIPTION
The controller method to handle retrying of an individual jobs was not
implemented (retry#update).

It looks like there was an intention for retry#create to handle
retrying of a collection of jobs and an individual job. I personally
like to seperate rest actions on a collection versus an invidual
resource instead of having one action handle both cases. Also, it seems
like to me the "retry" action belongs more with a job resource the same
way the "delete" action currently belongs to a job resource
