### PR TITLE
Sync Gemfile.lock with Gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,6 @@ GEM
       multi_json (~> 1.0)
     arel (3.0.2)
     builder (3.0.4)
-    coderay (1.0.9)
     coffee-rails (3.2.2)
       coffee-script (>= 2.2.0)
       railties (~> 3.2.0)
@@ -74,7 +73,6 @@ GEM
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     metaclass (0.0.1)
-    method_source (0.8.1)
     mime-types (1.21)
     minitest (4.7.0)
     minitest-spec-rails (4.7.2)
@@ -85,10 +83,6 @@ GEM
     mono_logger (1.0.0)
     multi_json (1.7.1)
     polyglot (0.3.3)
-    pry (0.9.12)
-      coderay (~> 1.0.5)
-      method_source (~> 0.8)
-      slop (~> 3.4)
     rack (1.4.5)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -136,7 +130,6 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.3)
       tilt (~> 1.3, >= 1.3.3)
-    slop (3.4.4)
     sprockets (2.2.2)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -175,7 +168,6 @@ DEPENDENCIES
   libv8 (= 3.11.8.13)
   minitest-spec-rails
   mocha
-  pry
   rails (= 3.2.13)
   redcard
   resque!


### PR DESCRIPTION
00c0f8b3 has pry + deps in Gemfile.lock, but it's not added in Gemfile, which makes `bundle install --deployment` fail.
