### PR TITLE
Use https git url for resque

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '3.2.13'
 
-gem 'resque', :git => 'git://github.com/resque/resque.git', :branch => "1-x-stable"
+gem 'resque', :git => 'https://github.com/resque/resque.git', :branch => "1-x-stable"
 
 group :test do
   gem 'minitest-spec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/resque/resque.git
+  remote: https://github.com/resque/resque.git
   revision: 8ee8a4bb43aeb5a9efcb4f1e9ad5ffd8dd0534e8
   branch: 1-x-stable
   specs:


### PR DESCRIPTION
This speeds up bundle install, since git connections to github are much slower than https.
