### PR TITLE
Allow setting an external resque server, backward support to defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,25 @@ and views.
 
 More documentation coming soon!
 
+## Starting
+As in any other rails server
+
+```
+rails s
+```
+
+or with predefined port:
+
+```
+rails s -p 9697
+```
+
+and, possibly, with a non default Resque server:
+
+```
+RAILS_RESQUE_REDIS=123.x.0.456:6712 rails s -p 3912
+```
+
 ## Screenshot
 
 ![Screenshot](http://i.imgur.com/LkNgl.png)

--- a/config/initializers/resque_config.rb
+++ b/config/initializers/resque_config.rb
@@ -1,0 +1,3 @@
+config = ENV.fetch("RAILS_RESQUE_REDIS", "127.0.0.1:6379")
+p "Starting resque-web against Resque server - #{config}"
+Resque.redis = config


### PR DESCRIPTION
In a real production system, you need to be able to configure Resque against a remote server and possibly a non default port.
Added documentation and code, no testing though, couldn't think of a meaningful way to test this.
