### PR TITLE
Suggested approach for adding a new 'last page' link in the failure queue

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,7 @@
 module ApplicationHelper
+  
+  PER_PAGE = 20
+
   def tabs
     %w(overview working failures queues workers stats)
   end
@@ -27,17 +30,16 @@ module ApplicationHelper
 
   def pagination(options = {})
     start    = options[:start] || 1
-    per_page = options[:per_page] || 20
+    per_page = options[:per_page] || PER_PAGE
     total    = options[:total] || 0
     return if total < per_page
 
     markup = ""
-
     if start - per_page >= 0
       markup << link_to(raw("&laquo; less"), params.merge(:start => start - per_page), :class => 'btn less')
     end
 
-    if start + 20 <= total
+    if start + per_page <= total
       markup << link_to(raw("more &raquo;"), params.merge(:start => start + per_page), :class => 'btn more')
     end
 

--- a/app/views/failures/index.html.erb
+++ b/app/views/failures/index.html.erb
@@ -7,6 +7,9 @@
 <% unless failure_size.zero? %>
   <%= form_tag(destroy_all_failures_path(:queue=>params[:queue]), :method => :delete) do %>
     <%= submit_tag "Clear #{params[:queue] ? "'#{params[:queue]}'" : 'Failed'} Jobs", :confirm => "Are you sure?", :class => 'btn btn-danger' %>
+    <% if failure_size >ApplicationHelper::PER_PAGE %>
+        <%= link_to "Last page &raquo;".html_safe, {:start => (failure_size - ApplicationHelper::PER_PAGE)}, :class => 'btn' %>
+    <% end %>          
   <% end %>
   <%= form_tag(retry_all_failures_path(:queue=>params[:queue]), :method => :put) do %>
     <%= submit_tag "Retry #{params[:queue] ? "'#{params[:queue]}'" : 'Failed'} Jobs", :class => 'btn' %>

--- a/app/views/failures/show.html.erb
+++ b/app/views/failures/show.html.erb
@@ -1,12 +1,12 @@
 <h1>Failed Jobs <%= "on '#{params[:id]}'" if params[:id] %> <%= "with class '#{params[:class]}'" if params[:class] %></h1>
 
-<% unless @jobs.empty? %>
-<%= form_tag("/failures/#{params[:id] if params[:id]}", :method => :delete) do %>
-  <%= submit_tag "Clear #{params[:id] ? "'#{params[:id]}'" : 'Failed'} Jobs", :confirm => "Are you sure?", :class => 'btn btn-danger' %>
-<% end %>
-<%= form_tag("/failures/#{params[:id] ? params[:id] : "all"}/retry") do %>
-  <%= submit_tag "Retry #{params[:id] ? "'#{params[:id]}'" : 'Failed'} Jobs", :class => 'btn' %>
-<% end %>
+<% if @jobs.any? %>
+  <%= form_tag("/failures/#{params[:id] if params[:id]}", :method => :delete) do %>
+    <%= submit_tag "Clear #{params[:id] ? "'#{params[:id]}'" : 'Failed'} Jobs", :confirm => "Are you sure?", :class => 'btn btn-danger' %>
+  <% end %>
+  <%= form_tag("/failures/#{params[:id] ? params[:id] : "all"}/retry") do %>
+    <%= submit_tag "Retry #{params[:id] ? "'#{params[:id]}'" : 'Failed'} Jobs", :class => 'btn' %>
+  <% end %>
 <% end %>
 
 <p class="sub">Showing <%= failure_start_at %> to <%= failure_end_at %> of <b><%= failure_size %></b> jobs</p>


### PR DESCRIPTION
So, this is just a suggested approach for this problem. This seems to work for our case where there are sometimes bursts of > 1000 failures and you want to quickly move to the last page.
While it's always possible to manually change the URL's "start" param manually, the intention here is to have this pre made.

Very much open for suggestions on this and suggestions on how to test this correctly.
