### PR TITLE
use time_ago_in_words for run_at on overview page

### DIFF
--- a/app/views/resque_web/working/_working.html.erb
+++ b/app/views/resque_web/working/_working.html.erb
@@ -24,7 +24,7 @@
         <td class="process">
           <% if job['queue'] %>
             <code><%= job['payload']['class'] %></code>
-            <small><%= job['run_at'] %></small>
+            <small><%= "#{time_ago_in_words job['run_at']} ago" %></small>
           <% else %>
             <span class="waiting">Waiting for a job...</span>
           <% end %>


### PR DESCRIPTION
This is just my preference for viewing when the job was enqueued on the front page. Opening a pull request to see if anyone is opposed or in favor of this.
