### PR TITLE
Qualify path to the poll.png asset_path

### DIFF
--- a/app/assets/stylesheets/resque_web/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/resque_web/bootstrap_and_overrides.css.scss
@@ -101,7 +101,7 @@ body {
 #footer { padding:10px 5%; background:#efefef; color:#999; font-size:85%; line-height:1.5; border-top:5px solid #ccc; padding-top:10px;}
 #footer p a { color:#999;}
 
-.container p.poll { background:url(image-url('poll.png')) no-repeat 0 2px; padding:3px 0; padding-left:23px; float:right; font-size:85%; }
+.container p.poll { background:url(image-url('resque_web/poll.png')) no-repeat 0 2px; padding:3px 0; padding-left:23px; float:right; font-size:85%; }
 
 .container ul.failed {margin-top: 20px;}
 .container ul.failed li {


### PR DESCRIPTION
Newer versions of Sprockets appear to be more strict, I'm receiving Sprockets::FileNotFound errors from the asset precompiler without this change.
