### PR TITLE
Prevent fatal when running resque-web engine with ruby 2.1.2 and rails 4.

### DIFF
--- a/config/initializers/resque_config.rb
+++ b/config/initializers/resque_config.rb
@@ -1,2 +1,4 @@
+require 'resque'
+
 config = ENV.fetch("RAILS_RESQUE_REDIS", "127.0.0.1:6379")
 Resque.redis = config


### PR DESCRIPTION
Getting this error when doing the steps in the Readme:

Uncaught exception: uninitialized constant Resque
	/Users/atkon/.rvm/gems/ruby-2.1.2@allplayers-resque-web/gems/resque-web-0.0.6/config/initializers/resque_config.rb:2:in `<top (required)>'