### PR TITLE
change helper Resque to global scope

### DIFF
--- a/app/helpers/resque_web/working_helper.rb
+++ b/app/helpers/resque_web/working_helper.rb
@@ -1,13 +1,13 @@
 module ResqueWeb
   module WorkingHelper
     def workers
-      @workers ||= Resque::WorkerRegistry.all
+      @workers ||= ::Resque::WorkerRegistry.all
     end
 
     def jobs
       @jobs ||= begin
                   workers.map do |worker|
-                    Resque::WorkerRegistry.new(worker).job
+                    ::Resque::WorkerRegistry.new(worker).job
                   end
                 end
     end


### PR DESCRIPTION
The Resque references caused a failure to launch since they were being locally scoped.  With the needed global scope the web interface seems to work. 
