### PR TITLE
Add an option to clear all pending jobs from a given queue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    resque-web (0.0.5)
+    resque-web (0.0.6)
       coffee-rails
       jquery-rails
       resque
@@ -58,10 +58,10 @@ GEM
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
-    coffee-script (2.2.0)
+    coffee-script (2.3.0)
       coffee-script-source
       execjs
-    coffee-script-source (1.7.0)
+    coffee-script-source (1.7.1)
     colorize (0.5.8)
     coveralls (0.6.7)
       colorize
@@ -78,7 +78,7 @@ GEM
     hike (1.2.3)
     i18n (0.6.9)
     jdbc-sqlite3 (3.7.2.1)
-    jquery-rails (3.1.0)
+    jquery-rails (3.1.1)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.1)
@@ -331,11 +331,12 @@ GEM
     rubysl-xmlrpc (2.0.0)
     rubysl-yaml (2.0.4)
     rubysl-zlib (2.0.1)
-    sass (3.3.2)
-    sass-rails (4.0.1)
+    sass (3.2.19)
+    sass-rails (4.0.3)
       railties (>= 4.0.0, < 5.0)
-      sass (>= 3.1.10)
-      sprockets-rails (~> 2.0.0)
+      sass (~> 3.2.0)
+      sprockets (~> 2.8, <= 2.11.0)
+      sprockets-rails (~> 2.0)
     simplecov (0.7.1)
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)

--- a/app/controllers/resque_web/queues_controller.rb
+++ b/app/controllers/resque_web/queues_controller.rb
@@ -13,5 +13,10 @@ module ResqueWeb
       redirect_to queues_path
     end
 
+    def clear
+      Resque.redis.del("queue:#{params[:id]}")
+      redirect_to queue_path(params[:id])
+    end
+
   end
 end

--- a/app/views/resque_web/queues/show.html.erb
+++ b/app/views/resque_web/queues/show.html.erb
@@ -1,5 +1,9 @@
   <h1>Pending jobs on <span class='hl'><%= params[:id] %></span></h1>
 
+  <%= form_tag(clear_queue_path(params[:id]), :method => :put) do %>
+    <%= submit_tag "Clear Pending Jobs", :class => 'btn btn-danger', :data => { :confirm => "Are you absolutely sure? This cannot be undone." } %>
+  <% end % %>
+
   <%= form_tag(queue_path(params[:id]), :method => :delete, :class => 'remove-queue') do %>
     <%= submit_tag "Remove Queue", :class => 'btn btn-danger', :data => { :confirm => "Are you absolutely sure? This cannot be undone." } %>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,11 @@ ResqueWeb::Engine.routes.draw do
 
   resource  :overview,  :only => [:show], :controller => :overview
   resources :working,   :only => [:index]
-  resources :queues,    :only => [:index,:show,:destroy], :constraints => {:id => id_pattern}
+  resources :queues,    :only => [:index,:show,:destroy], :constraints => {:id => id_pattern} do
+    member do
+      put 'clear' 
+    end
+  end
   resources :workers,   :only => [:index,:show], :constraints => {:id => id_pattern}
   resources :failures,  :only => [:show,:index,:destroy] do
     member do

--- a/test/functional/queues_controller_test.rb
+++ b/test/functional/queues_controller_test.rb
@@ -6,6 +6,7 @@ module ResqueWeb
 
     setup do
       @routes = Engine.routes
+      @pending_before_push = Resque.info[:pending]
       Resque.push(queue_name, class: 'ExampleJob')
     end
 
@@ -38,6 +39,19 @@ module ResqueWeb
       it "deletes queues" do
         visit(:destroy, {id: queue_name}, method: :delete)
         Resque.queues.include?(queue_name).wont_equal true
+      end
+    end
+
+    describe "PUT /clear" do
+      it "removes all pending jobs from a queue" do
+        visit(:clear, {id: queue_name}, method: :put)
+        pending_after_clear = Resque.info[:pending]
+        assert_equal @pending_before_push, pending_after_clear
+      end
+
+      it "redirects to the show page" do
+        visit(:clear, {id: queue_name}, method: :put)
+        assert_redirected_to queue_path(queue_name)
       end
     end
   end


### PR DESCRIPTION
When I'm developing an application that uses Resque, sometimes I need to clear all stale pending jobs in a queue. I do this through the command line but wanted a "Remove Pending Jobs" button next to the "Remove Queue" button in the web interface. When clicked, all pending jobs would be cleared from the queue but the queue itself would not be destroyed.

I wrote this feature (plus tests) and would like to contribute it if possible. As far as I know, this does not exist in the current web UI. If anyone has feedback or suggestions I will be very receptive of it. Thank you!
