### PR TITLE
Title Fix

### DIFF
--- a/app/views/layouts/resque_web/application.html.erb
+++ b/app/views/layouts/resque_web/application.html.erb
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width">
-  <title>Resque.</title>
+  <title>Resque - <%= controller_name %></title>
   <%= stylesheet_link_tag    "resque_web/application", :media => "all" %>
   <%= javascript_include_tag "resque_web/application" %>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
Pretty annoying to have the standard "Resque." in the title, so I used the Rails `controller_name` helper to spice things up. Now the title will read "Resque - Overview" etc