### PR TITLE
Let users delete a specific job from a queue in the web UI

### DIFF
--- a/app/controllers/resque_web/application_controller.rb
+++ b/app/controllers/resque_web/application_controller.rb
@@ -1,5 +1,6 @@
 module ResqueWeb
   class ApplicationController < ActionController::Base
+    include ActionView::Helpers::TextHelper
     protect_from_forgery
     before_filter :set_subtabs, :authorize
 

--- a/app/controllers/resque_web/jobs_controller.rb
+++ b/app/controllers/resque_web/jobs_controller.rb
@@ -1,0 +1,12 @@
+module ResqueWeb
+  class JobsController < ApplicationController
+  
+    def destroy
+      args = JSON.parse(params[:args])
+      destroyed = Resque::Job.destroy(params[:queue], params[:job_class], *args)
+      flash[:info] = "#{pluralize(destroyed, 'job')} deleted."
+      redirect_to queue_path(params[:queue])
+    end
+
+  end
+end

--- a/app/views/layouts/resque_web/application.html.erb
+++ b/app/views/layouts/resque_web/application.html.erb
@@ -44,6 +44,9 @@
 <% end %>
 
 <div class="container" id="main">
+  <% flash.each do |key, message| %>
+    <div class="alert alert-<%= key %>"><%= message %></div>
+  <% end %>
   <%= yield %>
 </div>
 

--- a/app/views/resque_web/queues/show.html.erb
+++ b/app/views/resque_web/queues/show.html.erb
@@ -13,11 +13,20 @@
     <tr>
       <th>Class</th>
       <th>Args</th>
+      <th>Actions</th>
     </tr>
     <% queue_jobs.each do |job| %>
     <tr>
       <td class='class'><%= job['class'] %></td>
       <td class='args'><%=h job['args'].inspect %></td>
+      <td class='actions'>
+        <%= form_tag(job_path(job['class']), :method => :delete) do %>
+          <%= hidden_field_tag :queue, params[:id] %>
+          <%= hidden_field_tag :job_class, job['class'] %>
+          <%= hidden_field_tag :args, JSON.dump(job['args']) %>
+          <%= submit_tag "Delete", :class => 'btn btn-default' %>
+        <% end %>
+      </td>
     </tr>
     <% end %>
     <% if queue_jobs.empty? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ ResqueWeb::Engine.routes.draw do
 
   resource  :overview,  :only => [:show], :controller => :overview
   resources :working,   :only => [:index]
+  resources :jobs,      :only => [:destroy], param: :job_class
   resources :queues,    :only => [:index,:show,:destroy], :constraints => {:id => id_pattern} do
     member do
       put 'clear' 

--- a/test/functional/jobs_controller_test.rb
+++ b/test/functional/jobs_controller_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+module ResqueWeb
+  class JobsControllerTest < ActionController::TestCase
+    include ControllerTestHelpers
+
+    let(:queue_name) { 'example_queue' }
+    let(:args)       { ['foo', 'bar'] }
+    let(:params)     { { queue: queue_name, job_class: 'ExampleJob', args: JSON.dump(args)} }
+
+    setup do
+      @routes = Engine.routes
+      Resque.push(queue_name, class: 'ExampleJob', args: args)
+      @queue_size = Resque.size(queue_name)
+    end
+
+    teardown do
+      Resque.remove_queue(queue_name)
+    end
+
+    describe "DELETE /destroy" do
+      let(:params_without_args) do
+        params.merge(:args => JSON.dump([]))
+      end
+
+      it "deletes a job having the specified arguments" do
+        visit(:destroy, params, method: :delete)
+        new_queue_size = Resque.size(queue_name)
+        assert_equal((@queue_size - 1), new_queue_size)
+      end
+
+      it "deletes all jobs of a class if no args are specified" do
+        Resque.push(queue_name, class: 'ExampleJob')
+        visit(:destroy, params_without_args, method: :delete)
+        new_queue_size = Resque.size(queue_name)
+        assert_equal(0, new_queue_size)
+      end
+
+      it "redirects to the queue's show page" do
+        visit(:destroy, params, method: :delete)
+        assert_redirected_to queue_path(queue_name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This feature places a "Delete" button next to each job in a queue. When that button is clicked, the enqueued job is removed and the user is taken back to the queue's page.

Summary of my changes:
- Added a JobsController with one action (destroy) that deletes a specific job. My reasoning behind creating a new controller is I think it's more RESTful than making a "delete_job" action in the QueuesController
- Added functional tests for my JobsController
- Added a new column called "Actions" on the queue's show page where the delete button for each job is housed

Here's an issue I want to bring up... since deleting a specific job relies on Resque::Job's class method `destroy` ([see here, please](http://rubydoc.info/github/defunkt/resque/Resque/Job.destroy)) some things might behave unexpectedly. Here's what I mean:
- As far as I know, Resque determines which job to delete based on a combination of the queue it's in, its job class, and the arguments to be passed to the job. We don't have an ID number. We might have multiple jobs with those same characteristics, and trying to delete one would delete ALL of them
- If no job arguments are passed to that method, Resque deletes all the jobs in that queue with that job class

There's one gem I found that gives UUIDs to Resque jobs ([resque-status](https://github.com/quirkey/resque-status)), but this gem would have to be present at the time someone creates a job and everyone would have to use this gem. We can't rely on that obviously.

The ball's in your court here, just let me know if there's a way I can improve this PR or if the above caveats make this a sort of undesirable feature. Thanks for taking the time to review this!
