### PR TITLE
Navigation bar working with both Bootstrap 2 and Bootstrap 3

### DIFF
--- a/app/assets/stylesheets/resque_web/bootstrap_and_overrides.css.scss.erb
+++ b/app/assets/stylesheets/resque_web/bootstrap_and_overrides.css.scss.erb
@@ -18,7 +18,7 @@ body {
   border-bottom: 5px solid #ce1212;
 }
 
-.navbar .brand {
+.navbar .brand, .navbar .navbar-brand {
   color: white;
 }
 

--- a/app/views/layouts/resque_web/application.html.erb
+++ b/app/views/layouts/resque_web/application.html.erb
@@ -15,15 +15,15 @@
 <div class="navbar navbar-inverse navbar-fixed-top">
   <div class="navbar-inner">
     <div class="container">
-      <a class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
+      <a class="btn btn-navbar navbar-toggle" data-toggle="collapse" data-target=".nav-collapse">
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </a>
       <%= image_tag "resque_web/lifebuoy.png", class: 'logo' %>
-      <%= link_to "Resque.", ResqueWeb::Engine.app.url_helpers.root_path, :class => "brand" %>
-      <div class="nav-collapse collapse">
-        <ul class="nav">
+      <%= link_to "Resque", ResqueWeb::Engine.app.url_helpers.root_path, :class => "brand navbar-brand" %>
+      <div class="nav-collapse navbar-collapse collapse">
+        <ul class="nav navbar-nav">
           <% tabs.each do |tab_name,path| %>
             <%= tab tab_name,path %>
           <% end %>


### PR DESCRIPTION
[rebased] I believe these limited changes will allow the Resque Web navigation bar to appear properly under both Bootstrap 2 and Bootstrap 3. Not sure if any other changes are required for Bootstrap 3.
