### PR TITLE
Updates libv8 gem to v3.16.14.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.1)
     json (1.8.1-java)
-    libv8 (3.16.14.3)
+    libv8 (3.16.14.7)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)


### PR DESCRIPTION
:information_desk_person: This change resolves installation issues on OS X, e.g. cowboyd/libv8#160