### PR TITLE
Navigation menu are highlighting when clicking a specific link.

### DIFF
--- a/app/helpers/resque_web/application_helper.rb
+++ b/app/helpers/resque_web/application_helper.rb
@@ -26,7 +26,7 @@ module ResqueWeb
     end
 
     def current_tab?(name)
-      params[:controller] == name.to_s
+      params[:controller].gsub(/resque_web\//, "") == name.to_s
     end
 
     attr_reader :subtabs


### PR DESCRIPTION
After analyzing the application_helper.rb, not getting appropriate controller name from params[:controller] variable to compare with tab name. Getting controller name like "resque_web/overview" instead got "overview".