### PR TITLE
Remove sass helper from bootstrap_and_overrides

### DIFF
--- a/app/assets/stylesheets/resque_web/bootstrap_and_overrides.css.scss.erb
+++ b/app/assets/stylesheets/resque_web/bootstrap_and_overrides.css.scss.erb
@@ -101,7 +101,7 @@ body {
 #footer { padding:10px 5%; background:#efefef; color:#999; font-size:85%; line-height:1.5; border-top:5px solid #ccc; padding-top:10px;}
 #footer p a { color:#999;}
 
-.container p.poll { background:url(image-url('<%= asset_path('resque_web/poll.png') %>')) no-repeat 0 2px; padding:3px 0; padding-left:23px; float:right; font-size:85%; }
+.container p.poll { background:url('<%= asset_path('resque_web/poll.png') %>') no-repeat 0 2px; padding:3px 0; padding-left:23px; float:right; font-size:85%; }
 
 .container ul.failed {margin-top: 20px;}
 .container ul.failed li {


### PR DESCRIPTION
I get an error in rails 4.2.0

![screenshot 2015-04-16 19 38 36](https://cloud.githubusercontent.com/assets/839922/7186419/34b79db6-e472-11e4-937c-1ef3cd4234a0.png)

This relates to #53 
I fixed it by removing sass helper.