### PR TITLE
Resque 2 relative URLs and url helper method_missing crashes in views

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    resque-web (0.0.5)
+    resque-web (0.0.6)
       coffee-rails
       jquery-rails
       resque
@@ -56,10 +56,10 @@ GEM
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
-    coffee-script (2.2.0)
+    coffee-script (2.3.0)
       coffee-script-source
       execjs
-    coffee-script-source (1.7.0)
+    coffee-script-source (1.7.1)
     colorize (0.5.8)
     coveralls (0.6.7)
       colorize
@@ -76,7 +76,7 @@ GEM
     hike (1.2.3)
     i18n (0.6.9)
     jdbc-sqlite3 (3.7.2.1)
-    jquery-rails (3.1.0)
+    jquery-rails (3.1.1)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.1)
@@ -327,11 +327,12 @@ GEM
     rubysl-xmlrpc (2.0.0)
     rubysl-yaml (2.0.4)
     rubysl-zlib (2.0.1)
-    sass (3.3.2)
-    sass-rails (4.0.1)
+    sass (3.2.19)
+    sass-rails (4.0.3)
       railties (>= 4.0.0, < 5.0)
-      sass (>= 3.1.10)
-      sprockets-rails (~> 2.0.0)
+      sass (~> 3.2.0)
+      sprockets (~> 2.8, <= 2.11.0)
+      sprockets-rails (~> 2.0)
     simplecov (0.7.1)
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)

--- a/app/assets/stylesheets/resque_web/bootstrap_and_overrides.css.scss.erb
+++ b/app/assets/stylesheets/resque_web/bootstrap_and_overrides.css.scss.erb
@@ -18,7 +18,7 @@ body {
   border-bottom: 5px solid #ce1212;
 }
 
-.navbar .brand {
+.navbar .brand, .navbar .navbar-brand {
   color: white;
 }
 
@@ -101,7 +101,7 @@ body {
 #footer { padding:10px 5%; background:#efefef; color:#999; font-size:85%; line-height:1.5; border-top:5px solid #ccc; padding-top:10px;}
 #footer p a { color:#999;}
 
-.container p.poll { background:url(image-url('resque_web/poll.png')) no-repeat 0 2px; padding:3px 0; padding-left:23px; float:right; font-size:85%; }
+.container p.poll { background:url(image-url('<%= asset_path('resque_web/poll.png') %>')) no-repeat 0 2px; padding:3px 0; padding-left:23px; float:right; font-size:85%; }
 
 .container ul.failed {margin-top: 20px;}
 .container ul.failed li {

--- a/app/controllers/resque_web/application_controller.rb
+++ b/app/controllers/resque_web/application_controller.rb
@@ -5,6 +5,10 @@ module ResqueWeb
 
     helper :all
 
+    def engine_url
+      ResqueWeb::Engine.app.url_helpers
+    end
+
     def self.subtabs(*tab_names)
       return defined?(@subtabs) ? @subtabs : [] if tab_names.empty?
       @subtabs = tab_names

--- a/app/controllers/resque_web/failures_controller.rb
+++ b/app/controllers/resque_web/failures_controller.rb
@@ -1,5 +1,5 @@
 module ResqueWeb
-  class FailuresController < ApplicationController
+  class FailuresController < ResqueWeb::ApplicationController
 
     # Display all jobs in the failure queue
     #

--- a/app/controllers/resque_web/failures_controller.rb
+++ b/app/controllers/resque_web/failures_controller.rb
@@ -12,20 +12,20 @@ module ResqueWeb
     # remove an individual job from the failure queue
     def destroy
       Resque::Failure.remove(params[:id])
-      redirect_to failures_path(redirect_params)
+      redirect_to resque_web.failures_path(redirect_params)
     end
 
     # destroy all jobs from the failure queue
     def destroy_all
       queue = params[:queue] || 'failed'
       Resque::Failure.clear(queue)
-      redirect_to failures_path(redirect_params)
+      redirect_to engine_url.failures_path(redirect_params)
     end
 
     # retry an individual job from the failure queue
     def retry
       reque_single_job(params[:id])
-      redirect_to failures_path(redirect_params)
+      redirect_to engine_url.failures_path(redirect_params)
     end
 
     # retry all jobs from the failure queue
@@ -35,7 +35,7 @@ module ResqueWeb
       else
         (Resque::Failure.count-1).downto(0).each { |id| reque_single_job(id) }
       end
-      redirect_to failures_path(redirect_params)
+      redirect_to engine_url.failures_path(redirect_params)
     end
 
     private

--- a/app/controllers/resque_web/overview_controller.rb
+++ b/app/controllers/resque_web/overview_controller.rb
@@ -1,5 +1,5 @@
 module ResqueWeb
-  class OverviewController < ApplicationController
+  class OverviewController < ResqueWeb::ApplicationController
     def show
       render :layout => !request.xhr?, :locals => { :polling => request.xhr? }
     end

--- a/app/controllers/resque_web/queues_controller.rb
+++ b/app/controllers/resque_web/queues_controller.rb
@@ -1,5 +1,5 @@
 module ResqueWeb
-  class QueuesController < ApplicationController
+  class QueuesController < ResqueWeb::ApplicationController
 
     def index
     end
@@ -12,5 +12,11 @@ module ResqueWeb
       Resque.remove_queue(params[:id])
       redirect_to engine_url.queues_path
     end
+
+    def clear
+      Resque.redis.del("queue:#{params[:id]}")
+      redirect_to engine_url.queue_path(params[:id])
+    end
+
   end
 end

--- a/app/controllers/resque_web/queues_controller.rb
+++ b/app/controllers/resque_web/queues_controller.rb
@@ -10,8 +10,7 @@ module ResqueWeb
 
     def destroy
       Resque.remove_queue(params[:id])
-      redirect_to queues_path
+      redirect_to engine_url.queues_path
     end
-
   end
 end

--- a/app/controllers/resque_web/stats_controller.rb
+++ b/app/controllers/resque_web/stats_controller.rb
@@ -4,7 +4,7 @@ module ResqueWeb
     subtabs :resque, :redis, :keys
 
     def index
-      redirect_to ResqueWeb::Engine.app.url_helpers.resque_stats_path
+      redirect_to engine_url.resque_stats_path
     end
 
     def resque

--- a/app/controllers/resque_web/stats_controller.rb
+++ b/app/controllers/resque_web/stats_controller.rb
@@ -1,5 +1,5 @@
 module ResqueWeb
-  class StatsController < ApplicationController
+  class StatsController < ResqueWeb::ApplicationController
     subtabs :resque, :redis, :keys
 
     def index

--- a/app/controllers/resque_web/stats_controller.rb
+++ b/app/controllers/resque_web/stats_controller.rb
@@ -1,9 +1,10 @@
 module ResqueWeb
   class StatsController < ResqueWeb::ApplicationController
+
     subtabs :resque, :redis, :keys
 
     def index
-      redirect_to action: "resque"
+      redirect_to ResqueWeb::Engine.app.url_helpers.resque_stats_path
     end
 
     def resque

--- a/app/controllers/resque_web/workers_controller.rb
+++ b/app/controllers/resque_web/workers_controller.rb
@@ -1,5 +1,5 @@
 module ResqueWeb
-  class WorkersController < ApplicationController
+  class WorkersController < ResqueWeb::ApplicationController
     before_filter :display_subtabs
 
     def index

--- a/app/controllers/resque_web/working_controller.rb
+++ b/app/controllers/resque_web/working_controller.rb
@@ -1,5 +1,5 @@
 module ResqueWeb
-  class WorkingController < ApplicationController
+  class WorkingController < ResqueWeb::ApplicationController
 
     def index
     end

--- a/app/helpers/resque_web/application_helper.rb
+++ b/app/helpers/resque_web/application_helper.rb
@@ -3,13 +3,20 @@ module ResqueWeb
 
     PER_PAGE = 20
 
+    # I don't know why I had to put this here. Should be able to
+    # include the proper url helper in the views. 4/16/15 -mikedll
+    def engine_url
+      ResqueWeb::Engine.app.url_helpers
+    end
+
     def tabs
-      t = {'overview' => ResqueWeb::Engine.app.url_helpers.overview_path,
-       'working'  => ResqueWeb::Engine.app.url_helpers.working_index_path,
-       'failures' => ResqueWeb::Engine.app.url_helpers.failures_path,
-       'queues' => ResqueWeb::Engine.app.url_helpers.queues_path,
-       'workers' => ResqueWeb::Engine.app.url_helpers.workers_path,
-       'stats' => ResqueWeb::Engine.app.url_helpers.stats_path
+      t = {
+        'overview' => engine_url.overview_path,
+        'working'  => engine_url.working_index_path,
+        'failures' => engine_url.failures_path,
+        'queues' => engine_url.queues_path,
+        'workers' => engine_url.workers_path,
+        'stats' => engine_url.stats_path
       }
       ResqueWeb::Plugins.plugins.each do |p|
         p.tabs.each { |tab| t.merge!(tab) }

--- a/app/helpers/resque_web/application_helper.rb
+++ b/app/helpers/resque_web/application_helper.rb
@@ -29,7 +29,7 @@ module ResqueWeb
     end
 
     def current_tab
-      params[:controller].gsub(/resque_web\//, "#{root_path}")
+      params[:controller].gsub(/resque_web\//, "#{engine_url.root_path}")
     end
 
     def current_tab?(name)

--- a/app/helpers/resque_web/application_helper.rb
+++ b/app/helpers/resque_web/application_helper.rb
@@ -50,15 +50,22 @@ module ResqueWeb
       start    = options[:start] || 1
       per_page = options[:per_page] || PER_PAGE
       total    = options[:total] || 0
+      if options[:use_route].nil?
+        url_params = params.slice(:action, :controller, :id)
+      else
+        url_params = params.slice(:id)
+        url_params.merge!({ :only_path => true, :use_route => options[:use_route] })
+      end
       return if total < per_page
+
 
       markup = ""
       if start - per_page >= 0
-        markup << link_to(raw("&laquo; less"), params.merge(:start => start - per_page), :class => 'btn less')
+        markup << link_to(raw("&laquo; less"), engine_url.url_for(url_params.merge(:start => start - per_page)), :class => 'btn less')
       end
 
       if start + per_page <= total
-        markup << link_to(raw("more &raquo;"), params.merge(:start => start + per_page), :class => 'btn more')
+        markup << link_to(raw("more &raquo;"), engine_url.url_for(url_params.merge(:start => start + per_page)), :class => 'btn more')
       end
 
       content_tag :p, raw(markup), :class => 'pagination'

--- a/app/helpers/resque_web/queues_helper.rb
+++ b/app/helpers/resque_web/queues_helper.rb
@@ -60,7 +60,7 @@ module ResqueWeb
 
       if size > 0
         css_class = "badge badge-important"
-        badge = link_to(size, failure_path(failed_queue))
+        badge = link_to(size, engine_url.failure_path(failed_queue))
       else
         css_class = "badge"
         badge = size.to_s

--- a/app/views/layouts/resque_web/application.html.erb
+++ b/app/views/layouts/resque_web/application.html.erb
@@ -15,15 +15,15 @@
 <div class="navbar navbar-inverse navbar-fixed-top">
   <div class="navbar-inner">
     <div class="container">
-      <a class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
+      <a class="btn btn-navbar navbar-toggle" data-toggle="collapse" data-target=".nav-collapse">
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </a>
       <%= image_tag "resque_web/lifebuoy.png", class: 'logo' %>
-      <%= link_to "Resque.", engine_url.root_path, :class => "brand" %>
-      <div class="nav-collapse collapse">
-        <ul class="nav">
+      <%= link_to "Resque.", engine_url.root_path, :class => "brand navbar-brand" %>
+      <div class="nav-collapse navbar-collapse collapse">
+        <ul class="nav navbar-nav">
           <% tabs.each do |tab_name,path| %>
             <%= tab tab_name,path %>
           <% end %>

--- a/app/views/layouts/resque_web/application.html.erb
+++ b/app/views/layouts/resque_web/application.html.erb
@@ -21,7 +21,7 @@
         <span class="icon-bar"></span>
       </a>
       <%= image_tag "resque_web/lifebuoy.png", class: 'logo' %>
-      <%= link_to "Resque.", ResqueWeb::Engine.app.url_helpers.root_path, :class => "brand" %>
+      <%= link_to "Resque.", engine_url.root_path, :class => "brand" %>
       <div class="nav-collapse collapse">
         <ul class="nav">
           <% tabs.each do |tab_name,path| %>

--- a/app/views/resque_web/failures/_failed_job.html.erb
+++ b/app/views/resque_web/failures/_failed_job.html.erb
@@ -13,20 +13,20 @@
       <% if job['retried_at'] %>
         <div class="retried">
           Retried <b><span class="time"><%= Time.parse(job['retried_at']).strftime(failure_date_format) %></span></b>
-          <%= link_to "Remove", failure_path(:queue=>failure_queue,:id=>id), :method => :delete, :class => 'remove', :rel => 'remove' %>
+          <%= link_to "Remove", engine_url.failure_path(:queue=>failure_queue,:id=>id), :method => :delete, :class => 'remove', :rel => 'remove' %>
         </div>
       <% else %>
         <div class="controls">
-          <%= link_to "Retry", retry_failure_path(:queue=>failure_queue,:id=>id), :method => :put %>
+          <%= link_to "Retry", engine_url.retry_failure_path(:queue=>failure_queue,:id=>id), :method => :put %>
           or
-          <%= link_to "Remove", failure_path(:queue=>failure_queue,:id=>id), :method => :delete %>
+          <%= link_to "Remove", engine_url.failure_path(:queue=>failure_queue,:id=>id), :method => :delete %>
         </div>
       <% end %>
     </dd>
     <dt>Class</dt>
     <dd>
       <% if job['payload'] && job['payload']['class'] %>
-        <%= link_to failures_path(:class=>job['payload']['class'],:queue=>params[:queue]) do %>
+        <%= link_to engine_url.failures_path(:class=>job['payload']['class'],:queue=>params[:queue]) do %>
           <code><%= job['payload']['class'] %></code>
         <% end %>
       <% else %>

--- a/app/views/resque_web/failures/_overview.html.erb
+++ b/app/views/resque_web/failures/_overview.html.erb
@@ -7,14 +7,14 @@
 
   <% Resque::Failure.queues.sort.each do |queue| %>
     <tr>
-      <th><%= link_to queue, failure_path(queue), :class => 'label label-info' %></th>
+      <th><%= link_to queue, engine_url.failure_path(queue), :class => 'label label-info' %></th>
       <th style="width:75px;" class="center"><%= Resque::Failure.count(queue) %></th>
     </tr>
 
     <% failure_class_counts(queue).each do |klass, count| %>
     <tr id="<%= klass %>">
       <td>
-        <%= link_to klass, failure_path(queue, :class => klass), :class => "failed failed_class" %>
+        <%= link_to klass, engine_url.failure_path(queue, :class => klass), :class => "failed failed_class" %>
       </td>
       <td style="text-align: center;" class="failed<%= (count.to_i > 1000) ? '_many' : '' %>"><%= count %></td>
     </tr>

--- a/app/views/resque_web/failures/index.html.erb
+++ b/app/views/resque_web/failures/index.html.erb
@@ -8,7 +8,7 @@
   <%= form_tag(engine_url.destroy_all_failures_path(queue: params[:queue]), method: :delete) do %>
     <%= submit_tag "Clear #{failure_queue_name} Jobs", class: 'btn btn-danger', data: { confirm: "Are you sure you want to clear ALL #{failure_queue_name.downcase} jobs?" } %>
     <% if failure_size > failure_per_page %>
-      <%= link_to "Last page &raquo;".html_safe, { start: (failure_size - failure_per_page) }, class: 'btn' %>
+      <%= link_to "Last page &raquo;".html_safe, engine_url.failures_path({ start: (failure_size - failure_per_page) }), class: 'btn' %>
     <% end %>
   <% end %>
   <%= form_tag(engine_url.retry_all_failures_path(queue: params[:queue]), method: :put) do %>
@@ -28,5 +28,5 @@
     <% end %>
   </ul>
 
-  <%= pagination(start: failure_start_at, total: failure_size) unless params[:class] %>
+  <%= pagination(:use_route => 'failures', start: failure_start_at, total: failure_size) unless params[:class] %>
 <% end %>

--- a/app/views/resque_web/failures/index.html.erb
+++ b/app/views/resque_web/failures/index.html.erb
@@ -5,13 +5,13 @@
 <% end %>
 
 <% unless failure_size.zero? %>
-  <%= form_tag(destroy_all_failures_path(queue: params[:queue]), method: :delete) do %>
+  <%= form_tag(engine_url.destroy_all_failures_path(queue: params[:queue]), method: :delete) do %>
     <%= submit_tag "Clear #{failure_queue_name} Jobs", class: 'btn btn-danger', data: { confirm: "Are you sure you want to clear ALL #{failure_queue_name.downcase} jobs?" } %>
     <% if failure_size > failure_per_page %>
       <%= link_to "Last page &raquo;".html_safe, { start: (failure_size - failure_per_page) }, class: 'btn' %>
     <% end %>
   <% end %>
-  <%= form_tag(retry_all_failures_path(queue: params[:queue]), method: :put) do %>
+  <%= form_tag(engine_url.retry_all_failures_path(queue: params[:queue]), method: :put) do %>
     <%= submit_tag "Retry #{failure_queue_name} Jobs", class: 'btn', data: { confirm: "Are you sure you want to retry ALL #{failure_queue_name.downcase} jobs?" } %>
   <% end %>
 <% end %>

--- a/app/views/resque_web/failures/show.html.erb
+++ b/app/views/resque_web/failures/show.html.erb
@@ -17,4 +17,4 @@
   <% end %>
 </ul>
 
-<%= pagination :start => failure_start_at, :total => failure_size unless params[:class] %>
+<%= pagination(:use_route => 'failures', :start => failure_start_at, :total => failure_size unless params[:class]) %>

--- a/app/views/resque_web/queues/_queues_advanced.html.erb
+++ b/app/views/resque_web/queues/_queues_advanced.html.erb
@@ -6,7 +6,7 @@
   </tr>
   <% queue_names.each do |queue_name| %>
   <tr>
-    <td class="queue"><%= link_to queue_name, queue_path(queue_name) %></td>
+    <td class="queue"><%= link_to queue_name, engine_url.queue_path(queue_name) %></td>
     <td class="size"><%= queue_size(queue_name) %></td>
     <td class="failure"><%= failed_queue_info(queue_name) %></td>
   </tr>

--- a/app/views/resque_web/queues/_queues_basic.html.erb
+++ b/app/views/resque_web/queues/_queues_basic.html.erb
@@ -5,13 +5,13 @@
   </tr>
   <% queue_names.each do |queue_name| %>
   <tr>
-    <td class="queue"><%= link_to queue_name, queue_path(queue_name) %></td>
+    <td class="queue"><%= link_to queue_name, engine_url.queue_path(queue_name) %></td>
     <td class="size"><%= queue_size(queue_name) %></td>
   </tr>
   <% end %>
 
   <tr class="<%= failed_queue_class('failed') %> first_failure">
-    <td class="queue failed"><%= link_to 'failed', failures_path, :class => 'queue' %></td>
+    <td class="queue failed"><%= link_to 'failed', engine_url.failures_path, :class => 'queue' %></td>
     <td class="size"><%= failed_queue_size('failed') %></td>
   </tr>
 </table>

--- a/app/views/resque_web/queues/show.html.erb
+++ b/app/views/resque_web/queues/show.html.erb
@@ -27,4 +27,4 @@
     <% end %>
   </table>
 
-  <%= pagination :start => queue_start_at, :total => queue_size %>
+  <%= pagination(:use_route => 'queues', :start => queue_start_at, :total => queue_size) %>

--- a/app/views/resque_web/queues/show.html.erb
+++ b/app/views/resque_web/queues/show.html.erb
@@ -1,5 +1,9 @@
   <h1>Pending jobs on <span class='hl'><%= params[:id] %></span></h1>
 
+  <%= form_tag(engine_url.clear_queue_path(params[:id]), :method => :put) do %>
+    <%= submit_tag "Clear Pending Jobs", :class => 'btn btn-danger', :data => { :confirm => "Are you absolutely sure? This cannot be undone." } %>
+  <% end % %>
+
   <%= form_tag(engine_url.queue_path(params[:id]), :method => :delete, :class => 'remove-queue') do %>
     <%= submit_tag "Remove Queue", :class => 'btn btn-danger', :data => { :confirm => "Are you absolutely sure? This cannot be undone." } %>
   <% end %>

--- a/app/views/resque_web/queues/show.html.erb
+++ b/app/views/resque_web/queues/show.html.erb
@@ -2,7 +2,7 @@
 
   <%= form_tag(engine_url.clear_queue_path(params[:id]), :method => :put) do %>
     <%= submit_tag "Clear Pending Jobs", :class => 'btn btn-danger', :data => { :confirm => "Are you absolutely sure? This cannot be undone." } %>
-  <% end % %>
+  <% end %>
 
   <%= form_tag(engine_url.queue_path(params[:id]), :method => :delete, :class => 'remove-queue') do %>
     <%= submit_tag "Remove Queue", :class => 'btn btn-danger', :data => { :confirm => "Are you absolutely sure? This cannot be undone." } %>

--- a/app/views/resque_web/queues/show.html.erb
+++ b/app/views/resque_web/queues/show.html.erb
@@ -1,6 +1,6 @@
   <h1>Pending jobs on <span class='hl'><%= params[:id] %></span></h1>
 
-  <%= form_tag(queue_path(params[:id]), :method => :delete, :class => 'remove-queue') do %>
+  <%= form_tag(engine_url.queue_path(params[:id]), :method => :delete, :class => 'remove-queue') do %>
     <%= submit_tag "Remove Queue", :class => 'btn btn-danger', :data => { :confirm => "Are you absolutely sure? This cannot be undone." } %>
   <% end %>
 

--- a/app/views/resque_web/stats/key.html.erb
+++ b/app/views/resque_web/stats/key.html.erb
@@ -22,5 +22,5 @@
     <% end %>
   </table>
 
-  <%= pagination :start => start, :total => size %>
+  <%= pagination(:use_route => 'keys_stats', :start => start, :total => size) %>
 <% end %>

--- a/app/views/resque_web/stats/keys.html.erb
+++ b/app/views/resque_web/stats/keys.html.erb
@@ -9,7 +9,7 @@
     </tr>
   <% Resque.keys.sort.each do |key| %>
     <tr>
-      <th><%= link_to key, statistic_path("keys", key) %></th>
+      <th><%= link_to key, engine_url.statistic_path("keys", key) %></th>
       <td><%= redis_key_type key %></td>
       <td><%= redis_key_size key %></td>
     </tr>

--- a/app/views/resque_web/workers/index.html.erb
+++ b/app/views/resque_web/workers/index.html.erb
@@ -8,12 +8,12 @@
     </tr>
     <% worker_hosts.each do |hostname, workers| %>
     <tr>
-      <td class="queue"><%= link_to hostname, worker_path(hostname), :class => 'queue' %></td>
+      <td class="queue"><%= link_to hostname, engine_url.worker_path(hostname), :class => 'queue' %></td>
       <td class="size"><%= workers.size %></td>
     </tr>
     <% end %>
     <tr class="failed">
-      <td class="queue failed"><%= link_to "all workers", worker_path('all'), :class => 'queue' %></td>
+      <td class="queue failed"><%= link_to "all workers", engine_url.worker_path('all'), :class => 'queue' %></td>
       <td class="size"><%= Resque::WorkerRegistry.all.size %></td>
     </tr>
   </table>

--- a/app/views/resque_web/workers/show.html.erb
+++ b/app/views/resque_web/workers/show.html.erb
@@ -16,7 +16,7 @@
       <td class="where"><%= host %>:<%= pid %></td>
       <td class="queues">
         <% queues.split(',').each do |queue_name| %>
-        <%= link_to queue_name, queue_path(queue_name), :class => 'label label-info' %>
+        <%= link_to queue_name, engine_url.queue_path(queue_name), :class => 'label label-info' %>
         <% end %>
       </td>
       <td class="process">

--- a/app/views/resque_web/working/_working.html.erb
+++ b/app/views/resque_web/working/_working.html.erb
@@ -17,9 +17,9 @@
       <tr>
         <td class="icon"><%= image_tag "resque_web/#{worker.state}.png", :alt => worker.state, :title => worker.state %></td>
         <% host, pid, queues = worker.to_s.split(':') %>
-        <td class="where"><%= link_to "#{host}:#{pid}", worker_path(host) %></td>
+        <td class="where"><%= link_to "#{host}:#{pid}", engine_url.worker_path(host) %></td>
         <td class="queues queue">
-          <%= link_to job['queue'], queue_path(job['queue']), :class => 'label label-info' %>
+          <%= link_to job['queue'], engine_url.queue_path(job['queue']), :class => 'label label-info' %>
         </td>
         <td class="process">
           <% if job['queue'] %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ ResqueWeb::Engine.routes.draw do
   resources :stats, :controller => "stats", :only => [:index] do
     collection do
       get :resque
+      get :keys
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,11 @@ ResqueWeb::Engine.routes.draw do
 
   resource  :overview,  :only => [:show], :controller => :overview
   resources :working,   :only => [:index]
-  resources :queues,    :only => [:index,:show,:destroy], :constraints => {:id => id_pattern}
+  resources :queues,    :only => [:index,:show,:destroy], :constraints => {:id => id_pattern} do
+    member do
+      put 'clear' 
+    end
+  end
   resources :workers,   :only => [:index,:show], :constraints => {:id => id_pattern}
   resources :failures,  :only => [:show,:index,:destroy] do
     member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,12 @@ ResqueWeb::Engine.routes.draw do
     end
   end
 
-  get '/stats' => "stats#index"
+  resources :stats, :controller => "stats", :only => [:index] do
+    collection do
+      get :resque
+    end
+  end
+
   get '/stats/:action',     :controller => :stats
   get '/stats/:action/:id', :controller => :stats, :constraints => {:id => id_pattern}, :as => :statistic
 

--- a/lib/resque_web/version.rb
+++ b/lib/resque_web/version.rb
@@ -1,3 +1,3 @@
 module ResqueWeb
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end

--- a/test/functional/queues_controller_test.rb
+++ b/test/functional/queues_controller_test.rb
@@ -6,6 +6,7 @@ module ResqueWeb
 
     setup do
       @routes = Engine.routes
+      @pending_before_push = Resque.info[:pending]
       Resque.push(queue_name, class: 'ExampleJob')
     end
 
@@ -38,6 +39,19 @@ module ResqueWeb
       it "deletes queues" do
         visit(:destroy, {id: queue_name}, method: :delete)
         Resque.queues.include?(queue_name).wont_equal true
+      end
+    end
+
+    describe "PUT /clear" do
+      it "removes all pending jobs from a queue" do
+        visit(:clear, {id: queue_name}, method: :put)
+        pending_after_clear = Resque.info[:pending]
+        assert_equal @pending_before_push, pending_after_clear
+      end
+
+      it "redirects to the show page" do
+        visit(:clear, {id: queue_name}, method: :put)
+        assert_redirected_to queue_path(queue_name)
       end
     end
   end


### PR DESCRIPTION
Seems to be working.

Pulled in several adjustments from master.

Added a couple of my own related to keeping the URLs relative to the engine after it is included in an Rails application, or even to keep it from crashing outright. I'm surprised it works for others in this use case.

