### PR TITLE
Show the arguments for working jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,17 @@ vendor/ruby
 *.rdb
 Vagrantfile
 .vagrant
+
+.idea/.name
+
+.idea/.rakeTasks
+
+.idea/misc.xml
+
+.idea/modules.xml
+
+.idea/resque-web.iml
+
+.idea/vcs.xml
+
+.idea/workspace.xml

--- a/.gitignore
+++ b/.gitignore
@@ -28,16 +28,3 @@ vendor/ruby
 Vagrantfile
 .vagrant
 
-.idea/.name
-
-.idea/.rakeTasks
-
-.idea/misc.xml
-
-.idea/modules.xml
-
-.idea/resque-web.iml
-
-.idea/vcs.xml
-
-.idea/workspace.xml

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,3 @@ vendor/ruby
 *.rdb
 Vagrantfile
 .vagrant
-

--- a/app/views/resque_web/queues/show.html.erb
+++ b/app/views/resque_web/queues/show.html.erb
@@ -2,7 +2,7 @@
 
   <%= form_tag(clear_queue_path(params[:id]), :method => :put) do %>
     <%= submit_tag "Clear Pending Jobs", :class => 'btn btn-danger', :data => { :confirm => "Are you absolutely sure? This cannot be undone." } %>
-  <% end % %>
+  <% end %>
 
   <%= form_tag(queue_path(params[:id]), :method => :delete, :class => 'remove-queue') do %>
     <%= submit_tag "Remove Queue", :class => 'btn btn-danger', :data => { :confirm => "Are you absolutely sure? This cannot be undone." } %>

--- a/app/views/resque_web/working/_working.html.erb
+++ b/app/views/resque_web/working/_working.html.erb
@@ -23,7 +23,7 @@
         </td>
         <td class="process">
           <% if job['queue'] %>
-            <code><%= job['payload']['class'] %></code>
+            <code><%= job['payload']['class'] %><br/><%= job['payload']['args'].to_s %></code>
             <small><%= "#{time_ago_in_words job['run_at']} ago" %></small>
           <% else %>
             <span class="waiting">Waiting for a job...</span>

--- a/app/views/resque_web/working/_working.html.erb
+++ b/app/views/resque_web/working/_working.html.erb
@@ -23,7 +23,7 @@
         </td>
         <td class="process">
           <% if job['queue'] %>
-            <code><%= job['payload']['class'] %><br/><%= job['payload']['args'].to_s %></code>
+            <code><%= job['payload']['class'] %><br/>Args: <%= job['payload']['args'].to_s %></code>
             <small><%= "#{time_ago_in_words job['run_at']} ago" %></small>
           <% else %>
             <span class="waiting">Waiting for a job...</span>


### PR DESCRIPTION
I've recently upgraded our application to rails 4.2 and have started using ActiveJob with Resque. Using resque-web, when a job is working, I only see the rails Resque job wrapper as the class.

```
ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper
```

This PR adds displaying the job arguments to the Processing Queue. It is nice to be able to see what type of job is long running in the resque-web interface. I'm not sure that this is the best way to do this, but I wanted to open a conversation about adding some more info in the Processing listing. With the addition of args, I can see what actual job is running, which is helpful for diagnosing any issues that we might be having.