### PR TITLE
Use asset_manifest when necessary

### DIFF
--- a/app/views/layouts/resque_web/application.html.erb
+++ b/app/views/layouts/resque_web/application.html.erb
@@ -9,7 +9,9 @@
   <%= stylesheet_link_tag "resque_web/application", :media => "all" %>
   <%=
       ResqueWeb::Plugins.plugins.collect do |p|
-        if Rails.application.assets.find_asset("#{p.name.underscore.downcase}/application.css")
+        file_path = "#{p.name.underscore.downcase}/application.css"
+        if (Rails.application.assets && Rails.application.assets.find_asset(file_path)) ||
+           (Rails.application.assets_manifest && Rails.application.assets_manifest.assets[file_path])
           stylesheet_link_tag "#{p.name.underscore.downcase}/application"
         end
       end.join("\n").html_safe
@@ -17,7 +19,9 @@
   <%= javascript_include_tag "resque_web/application" %>
   <%=
       ResqueWeb::Plugins.plugins.collect do |p|
-        if Rails.application.assets.find_asset("#{p.name.underscore.downcase}/application.js")
+        file_path = "#{p.name.underscore.downcase}/application.js"
+        if (Rails.application.assets && Rails.application.assets.find_asset(file_path)) ||
+           (Rails.application.assets_manifest && Rails.application.assets_manifest.assets[file_path])
           javascript_include_tag "#{p.name.underscore.downcase}/application"
         end
       end.join("\n").html_safe


### PR DESCRIPTION
This fixes https://github.com/mattgibson/resque-scheduler-web/issues/5 where Rails 4.2.5 was erroring when plugins were in use. The issue is outlined here https://stackoverflow.com/questions/35154588/rails-sprockets-3-0-find-asset where the find_asset method is not available due to a different version of sprockets.