### PR TITLE
removing test files from built gem

### DIFF
--- a/resque_web.gemspec
+++ b/resque_web.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.licenses    = ['MIT']
 
   s.files = Dir["{app,config,lib}/**/*", "Rakefile", "README.md"]
-  s.test_files = Dir["test/**/*"]
 
   s.add_dependency "resque"
   s.add_dependency 'twitter-bootstrap-rails'


### PR DESCRIPTION
I saw that resque-web is including all of the tests in the released gem - the test directory includes a lot of extra files that I don't think are needed at runtime, especially in the test/dummy directory. The test directory weighs in at 4.1Mb out of a total 4.3Mb gem (~95% of total size).

I'm using resque-web with docker and was looking for ways to slim down my image layers and an extra 4Mb across lots of gems really add up.
