### PR TITLE
Resque-web should not set the global Resque.redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ MyApp::Application.routes.draw do
 end
 ```
 
-If you need a non-default resque server, use this environment variable.
+If `RAILS_RESQUE_REDIS` is set in `ENV` and is not the empty string, this gem will set `Resque.redis` equal to `ENV['RAILS_RESQUE_REDIS']` in an initializer.
 
-```
-RAILS_RESQUE_REDIS=123.x.0.456:6712
-```
+For info on configuring Resque itself (and accepted values of `Resque.redis`) see [the Configuration section of the Resque README](https://github.com/resque/resque#configuration).
+
+
 ## Security
 
 You almost certainly want to limit access when using resque-web in production. Using [routes constraints](http://guides.rubyonrails.org/routing.html#request-based-constraints) is one way to achieve this:

--- a/config/initializers/resque_config.rb
+++ b/config/initializers/resque_config.rb
@@ -1,4 +1,8 @@
 require 'resque'
 
-config = ENV.fetch("RAILS_RESQUE_REDIS", "127.0.0.1:6379")
-Resque.redis = config
+# Previously, this initializer always set Resque.redis, and defaulted to '127.0.0.1:6379' if
+# RAILS_RESQUE_REDIS was not set.
+
+if ENV['RAILS_RESQUE_REDIS'] && ENV['RAILS_RESQUE_REDIS'].length
+  Resque.redis = ENV['RAILS_RESQUE_REDIS']
+end


### PR DESCRIPTION
Hey-- thanks for the awesome gem! We use it all the time to monitor Resque jobs.

That said, I think resque-web should not set `Resque.redis`. This broke our app today, because we set `Resque.redis` in a different initializer, using a different environment variable, and the load order changed-- I had no idea that resque-web had a `Resque.redis = ...` call in an initializer.

I realize this is a breaking change, but it seems a bit strange and dangerous to have resque-web handle this logic, since that's a contract between the user and the Resque gem itself.

What do you think?


