### PR TITLE
Update show.html.erb

### DIFF
--- a/app/views/resque_web/workers/show.html.erb
+++ b/app/views/resque_web/workers/show.html.erb
@@ -9,7 +9,7 @@
       <th>Processing</th>
     </tr>
     <% @workers.each do |worker| %>
-    <tr class="<% worker.state %>">
+    <tr class="<%= worker.state %>">
       <td class="icon"><%= image_tag "resque_web/#{worker.state}.png", :alt => worker.state, :title => worker.state %></td>
 
       <% host, pid, queues = worker.to_s.split(':') %>


### PR DESCRIPTION
Fix `Ruby statement not allowed` error in workers#show view.

This showed up in our logs after a Rails upgrade.