### PR TITLE
Clear and Retry jobs by job class and exception

### DIFF
--- a/app/controllers/resque_web/failures_controller.rb
+++ b/app/controllers/resque_web/failures_controller.rb
@@ -18,7 +18,11 @@ module ResqueWeb
     # destroy all jobs from the failure queue
     def destroy_all
       queue = params[:queue] || 'failed'
-      Resque::Failure.clear(queue)
+
+      (Resque::Failure.count - 1).downto(0).each do |i|
+        Resque::Failure.remove(i) if must_execute_action_for(i)
+      end
+
       redirect_to failures_path(redirect_params)
     end
 
@@ -30,11 +34,14 @@ module ResqueWeb
 
     # retry all jobs from the failure queue
     def retry_all
-      if params[:queue].present? && params[:queue]!="failed"
+      if params[:queue].present? && params[:queue] != 'failed'
         Resque::Failure.requeue_queue(params[:queue])
       else
-        (Resque::Failure.count-1).downto(0).each { |id| reque_single_job(id) }
+        (Resque::Failure.count - 1).downto(0).each do |i|
+          reque_single_job(i) if must_execute_action_for(i)
+        end
       end
+
       redirect_to failures_path(redirect_params)
     end
 
@@ -58,5 +65,17 @@ module ResqueWeb
       end
     end
 
+    def must_execute_action_for(i)
+      (params[:job_class].blank? || params[:job_class] == job_class_for(i)) &&
+      (params[:job_exception].blank? || params[:job_exception] == job_exception_for(i))
+    end
+
+    def job_class_for(i)
+      Resque::Failure.all(i)['payload']['args'].first['job_class']
+    end
+
+    def job_exception_for(i)
+      Resque::Failure.all(i)['exception']
+    end
   end
 end

--- a/app/views/resque_web/failures/index.html.erb
+++ b/app/views/resque_web/failures/index.html.erb
@@ -5,15 +5,29 @@
 <% end %>
 
 <% unless failure_size.zero? %>
-  <%= form_tag(destroy_all_failures_path(queue: params[:queue]), method: :delete) do %>
-    <%= submit_tag "Clear #{failure_queue_name} Jobs", class: 'btn btn-danger', data: { confirm: "Are you sure you want to clear ALL #{failure_queue_name.downcase} jobs?" } %>
+  <div class='row'>
+    <%= form_tag(destroy_all_failures_path(queue: params[:queue]), class: 'form-inline', method: :delete) do |form| %>
+      <%= text_field form, :job_class, class: 'form-control', placeholder: 'Arguments Job Class' %>
+      <%= text_field form, :job_exception, class: 'form-control', placeholder: 'Job Exception' %>
+      <%= submit_tag "Clear #{failure_queue_name} Jobs", class: 'btn btn-danger', data: { confirm: "Are you sure you want to clear the #{failure_queue_name.downcase} jobs?" } %>
+    <% end %>
+  </div>
+
+  <br>
+
+  <div class='row'>
+    <%= form_tag(retry_all_failures_path(queue: params[:queue]), class: 'form-inline', method: :put) do |form| %>
+      <%= text_field form, :job_class, class: 'form-control', placeholder: 'Arguments Job Class' %>
+      <%= text_field form, :job_exception, class: 'form-control', placeholder: 'Job Exception' %>
+      <%= submit_tag "Retry #{failure_queue_name} Jobs", class: 'btn btn-primary', data: { confirm: "Are you sure you want to retry the #{failure_queue_name.downcase} jobs?" } %>
+    <% end %>
+  </div>
+
+  <div class='row pull-right'>
     <% if failure_size > failure_per_page %>
       <%= link_to "Last page &raquo;".html_safe, { start: (failure_size - failure_per_page) }, class: 'btn' %>
     <% end %>
-  <% end %>
-  <%= form_tag(retry_all_failures_path(queue: params[:queue]), method: :put) do %>
-    <%= submit_tag "Retry #{failure_queue_name} Jobs", class: 'btn', data: { confirm: "Are you sure you want to retry ALL #{failure_queue_name.downcase} jobs?" } %>
-  <% end %>
+  </div>
 <% end %>
 
 <% if multiple_failure_queues? && !params[:queue] %>

--- a/app/views/resque_web/failures/show.html.erb
+++ b/app/views/resque_web/failures/show.html.erb
@@ -1,4 +1,4 @@
-<h1>Failed Jobs <%= "on '#{params[:id]}'" if params[:id] %> <%= "with class '#{params[:class]}'" if params[:class] %></h1>
+<h1>Failed jobs <%= "on '#{params[:id]}'" if params[:id] %> <%= "with class '#{params[:class]}'" if params[:class] %></h1>
 
 <% if @jobs.any? %>
   <%= form_tag("/failures/#{params[:id] if params[:id]}", :method => :delete) do %>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2650702/48939402-62c0ff80-ef14-11e8-9ae6-c12cfa02ba3f.png)

With this, we can retry or clean only the jobs which a specific job class or job exception. If empty, it works as it used to work.